### PR TITLE
delete system_packages setting from .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,4 +22,3 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
-  system_packages: true


### PR DESCRIPTION
see detail:
https://blog.readthedocs.com/drop-support-system-packages/