### PR TITLE
simplify instantiation of RiquConfig

### DIFF
--- a/docs_html/quri_parts/riqu/quri_parts.riqu.backend.html
+++ b/docs_html/quri_parts/riqu/quri_parts.riqu.backend.html
@@ -251,7 +251,7 @@
 
 <dl class="py method">
 <dt class="sig sig-object py" id="quri_parts.riqu.backend.RiquConfig.from_file">
-<em class="property"><span class="pre">static</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">from_file</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">section</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><span class="pre">str</span></span><span class="w"> </span><span class="o"><span class="pre">=</span></span><span class="w"> </span><span class="default_value"><span class="pre">'default'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">path</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><span class="pre">str</span></span><span class="w"> </span><span class="o"><span class="pre">=</span></span><span class="w"> </span><span class="default_value"><span class="pre">'~/.riqu'</span></span></em><span class="sig-paren">)</span> <span class="sig-return"><span class="sig-return-icon">&#x2192;</span> <span class="sig-return-typehint"><span class="pre">Dict</span><span class="p"><span class="pre">[</span></span><span class="pre">str</span><span class="p"><span class="pre">,</span></span><span class="w"> </span><span class="pre">str</span><span class="p"><span class="pre">]</span></span></span></span><a class="headerlink" href="#quri_parts.riqu.backend.RiquConfig.from_file" title="Permalink to this definition">#</a></dt>
+<em class="property"><span class="pre">static</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">from_file</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">section</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><span class="pre">str</span></span><span class="w"> </span><span class="o"><span class="pre">=</span></span><span class="w"> </span><span class="default_value"><span class="pre">'default'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">path</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><span class="pre">str</span></span><span class="w"> </span><span class="o"><span class="pre">=</span></span><span class="w"> </span><span class="default_value"><span class="pre">'~/.riqu'</span></span></em><span class="sig-paren">)</span> <span class="sig-return"><span class="sig-return-icon">&#x2192;</span> <span class="sig-return-typehint"><a class="reference internal" href="quri_parts.riqu.backend.sampling.html#quri_parts.riqu.backend.sampling.RiquConfig" title="quri_parts.riqu.backend.sampling.RiquConfig"><span class="pre">quri_parts.riqu.backend.sampling.RiquConfig</span></a></span></span><a class="headerlink" href="#quri_parts.riqu.backend.RiquConfig.from_file" title="Permalink to this definition">#</a></dt>
 <dd><p>Reads configuration information from a file.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
@@ -261,12 +261,12 @@
 </ul>
 </dd>
 <dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Configuration information in dict .</p>
+<dd class="field-even"><p>Configuration information <a class="reference internal" href="#quri_parts.riqu.backend.RiquConfig" title="quri_parts.riqu.backend.RiquConfig"><code class="xref py py-class docutils literal notranslate"><span class="pre">RiquConfig</span></code></a> .</p>
 </dd>
 </dl>
 <p class="rubric">Examples</p>
 <p>The riqu configuration file describes configuration information for each
-section. A section has a header in the form <code class="docutils literal notranslate"><span class="pre">[section_name]</span></code>.
+section. A section has a header in the form <code class="docutils literal notranslate"><span class="pre">[section]</span></code>.
 The default file path is <code class="docutils literal notranslate"><span class="pre">~/.riqu</span></code> and the default section name is
 <code class="docutils literal notranslate"><span class="pre">default</span></code>. Each section describes a setting in the format <code class="docutils literal notranslate"><span class="pre">key=value</span></code>.
 An example of a configuration file description is as below:</p>

--- a/docs_html/quri_parts/riqu/quri_parts.riqu.backend.sampling.html
+++ b/docs_html/quri_parts/riqu/quri_parts.riqu.backend.sampling.html
@@ -520,7 +520,7 @@ then cannot be cancelled and an error occurs.</p>
 
 <dl class="py method">
 <dt class="sig sig-object py" id="quri_parts.riqu.backend.sampling.RiquConfig.from_file">
-<em class="property"><span class="pre">static</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">from_file</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">section</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><span class="pre">str</span></span><span class="w"> </span><span class="o"><span class="pre">=</span></span><span class="w"> </span><span class="default_value"><span class="pre">'default'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">path</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><span class="pre">str</span></span><span class="w"> </span><span class="o"><span class="pre">=</span></span><span class="w"> </span><span class="default_value"><span class="pre">'~/.riqu'</span></span></em><span class="sig-paren">)</span> <span class="sig-return"><span class="sig-return-icon">&#x2192;</span> <span class="sig-return-typehint"><span class="pre">Dict</span><span class="p"><span class="pre">[</span></span><span class="pre">str</span><span class="p"><span class="pre">,</span></span><span class="w"> </span><span class="pre">str</span><span class="p"><span class="pre">]</span></span></span></span><a class="headerlink" href="#quri_parts.riqu.backend.sampling.RiquConfig.from_file" title="Permalink to this definition">#</a></dt>
+<em class="property"><span class="pre">static</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">from_file</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">section</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><span class="pre">str</span></span><span class="w"> </span><span class="o"><span class="pre">=</span></span><span class="w"> </span><span class="default_value"><span class="pre">'default'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">path</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><span class="pre">str</span></span><span class="w"> </span><span class="o"><span class="pre">=</span></span><span class="w"> </span><span class="default_value"><span class="pre">'~/.riqu'</span></span></em><span class="sig-paren">)</span> <span class="sig-return"><span class="sig-return-icon">&#x2192;</span> <span class="sig-return-typehint"><a class="reference internal" href="#quri_parts.riqu.backend.sampling.RiquConfig" title="quri_parts.riqu.backend.sampling.RiquConfig"><span class="pre">quri_parts.riqu.backend.sampling.RiquConfig</span></a></span></span><a class="headerlink" href="#quri_parts.riqu.backend.sampling.RiquConfig.from_file" title="Permalink to this definition">#</a></dt>
 <dd><p>Reads configuration information from a file.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
@@ -530,12 +530,12 @@ then cannot be cancelled and an error occurs.</p>
 </ul>
 </dd>
 <dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Configuration information in dict .</p>
+<dd class="field-even"><p>Configuration information <a class="reference internal" href="#quri_parts.riqu.backend.sampling.RiquConfig" title="quri_parts.riqu.backend.sampling.RiquConfig"><code class="xref py py-class docutils literal notranslate"><span class="pre">RiquConfig</span></code></a> .</p>
 </dd>
 </dl>
 <p class="rubric">Examples</p>
 <p>The riqu configuration file describes configuration information for each
-section. A section has a header in the form <code class="docutils literal notranslate"><span class="pre">[section_name]</span></code>.
+section. A section has a header in the form <code class="docutils literal notranslate"><span class="pre">[section]</span></code>.
 The default file path is <code class="docutils literal notranslate"><span class="pre">~/.riqu</span></code> and the default section name is
 <code class="docutils literal notranslate"><span class="pre">default</span></code>. Each section describes a setting in the format <code class="docutils literal notranslate"><span class="pre">key=value</span></code>.
 An example of a configuration file description is as below:</p>

--- a/quri_parts/riqu/backend/sampling.py
+++ b/quri_parts/riqu/backend/sampling.py
@@ -384,7 +384,7 @@ class RiquConfig:
         return self._api_token
 
     @staticmethod
-    def from_file(section: str = "default", path: str = "~/.riqu") -> Dict[str, str]:
+    def from_file(section: str = "default", path: str = "~/.riqu") -> "RiquConfig":
         """Reads configuration information from a file.
 
         Args:
@@ -392,11 +392,11 @@ class RiquConfig:
             path: A path for config file.
 
         Returns:
-            Configuration information in dict .
+            Configuration information :class:`RiquConfig` .
 
         Examples:
             The riqu configuration file describes configuration information for each
-            section. A section has a header in the form ``[section_name]``.
+            section. A section has a header in the form ``[section]``.
             The default file path is ``~/.riqu`` and the default section name is
             ``default``. Each section describes a setting in the format ``key=value``.
             An example of a configuration file description is as below:
@@ -411,11 +411,11 @@ class RiquConfig:
         path = os.path.expanduser(path)
         parser = configparser.ConfigParser()
         parser.read(path, encoding="utf-8")
-        config_dict = {
-            "url": parser[section]["url"],
-            "api_token": parser[section]["api_token"],
-        }
-        return config_dict
+        config = RiquConfig(
+            url=parser[section]["url"],
+            api_token=parser[section]["api_token"],
+        )
+        return config
 
 
 class RiquSamplingBackend(SamplingBackend):

--- a/quri_parts/riqu/backend/sampling.py
+++ b/quri_parts/riqu/backend/sampling.py
@@ -434,8 +434,7 @@ class RiquSamplingBackend(SamplingBackend):
 
         # if config is None, load them from file
         if config is None:
-            config_dict = RiquConfig.from_file()
-            config = RiquConfig(**config_dict)
+            config = RiquConfig.from_file()
 
         # construct JobApi
         rest_config = Configuration()

--- a/tests/riqu/backend/test_sampling.py
+++ b/tests/riqu/backend/test_sampling.py
@@ -448,8 +448,8 @@ class TestRiquConfig:
         actual = RiquConfig.from_file()
 
         # Assert
-        assert actual["url"] == "default_url"
-        assert actual["api_token"] == "default_api_token"
+        assert actual.url == "default_url"
+        assert actual.api_token == "default_api_token"
 
     def test_from_file__section(self, mocker):
         # Arrange
@@ -459,8 +459,8 @@ class TestRiquConfig:
         actual = RiquConfig.from_file(section="test")
 
         # Assert
-        assert actual["url"] == "test_url"
-        assert actual["api_token"] == "test_api_token"
+        assert actual.url == "test_url"
+        assert actual.api_token == "test_api_token"
 
     def test_from_file__wrong(self, mocker):
         # Arrange


### PR DESCRIPTION
You can specify a `section` other than default in the `.riqu` file to generate a `backend` as follows:

`backend = RiquSamplingBackend(RiquConfig.from_file("section"))`